### PR TITLE
Switch from array to mapping for zapConfigs

### DIFF
--- a/contracts/SettToRenIbbtcZap.sol
+++ b/contracts/SettToRenIbbtcZap.sol
@@ -100,6 +100,20 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
             address(WBTC),
             2 // idx - renbtc: 1, wbtc: 2
         );
+        _setZapConfig(
+            0x55912D0Cf83B75c492E761932ABc4DB4a5CB1b17, // bcrvPBTC
+            0xDE5331AC4B3630f94853Ff322B66407e0D6331E8, // pbtcCrv
+            0x11F419AdAbbFF8d595E7d5b223eee3863Bb3902C, // pbtcCrv zap
+            address(WBTC),
+            2 // idx - renbtc: 1, wbtc: 2
+        );
+        _setZapConfig(
+            0xf349c0faA80fC1870306Ac093f75934078e28991, // bcrvOBTC
+            0x2fE94ea3d5d4a175184081439753DE15AeF9d614, // obtcCrv
+            0xd5BCf53e2C81e1991570f33Fa881c49EEa570C8D, // obtcCrv zap
+            address(WBTC),
+            2 // idx - renbtc: 1, wbtc: 2
+        );
     }
 
     /// ===== Modifiers =====

--- a/contracts/SettToRenIbbtcZap.sol
+++ b/contracts/SettToRenIbbtcZap.sol
@@ -21,13 +21,12 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
     address public governance;
 
     struct ZapConfig {
-        ISett sett;
         IERC20Upgradeable token;
         ICurveFi curvePool;
         IERC20Upgradeable withdrawToken;
         int128 withdrawTokenIndex;
     }
-    ZapConfig[] public zapConfigs;
+    mapping(address => ZapConfig) public settZapConfigs;
 
     IERC20Upgradeable public constant WBTC =
         IERC20Upgradeable(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
@@ -66,35 +65,35 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
         RENBTC.safeApprove(address(IBBTC_MINT_ZAP), type(uint256).max);
 
         // Add zap configs for setts
-        _addZapConfig(
+        _setZapConfig(
             WBTC_YEARN_SETT, // byvWBTC
             address(WBTC),
             address(0), // No curve pool
             address(WBTC),
             0 // No curve pool
         );
-        _addZapConfig(
+        _setZapConfig(
             0xd04c48A53c111300aD41190D63681ed3dAd998eC, // bcrvSBTC
             0x075b1bb99792c9E1041bA13afEf80C91a1e70fB3, // sbtcCrv
             0x7fC77b5c7614E1533320Ea6DDc2Eb61fa00A9714, // sbtcCrv curve pool
             address(WBTC),
             1 // idx - renbtc: 0, wbtc: 1
         );
-        _addZapConfig(
+        _setZapConfig(
             0xb9D076fDe463dbc9f915E5392F807315Bf940334, // bcrvTBTC
             0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd, // tbtcCrv
             0xaa82ca713D94bBA7A89CEAB55314F9EfFEdDc78c, // tbtcCrv zap
             address(WBTC),
             2 // idx - renbtc: 1, wbtc: 2
         );
-        _addZapConfig(
+        _setZapConfig(
             0x8c76970747afd5398e958bDfadA4cf0B9FcA16c4, // bcrvHBTC
             0xb19059ebb43466C323583928285a49f558E572Fd, // hbtcCrv
             0x4CA9b3063Ec5866A4B82E437059D2C43d1be596F, // hbtcCrv curve pool
             address(WBTC),
             1 // idx - wbtc: 1
         );
-        _addZapConfig(
+        _setZapConfig(
             0x5Dce29e92b1b939F8E8C60DcF15BDE82A85be4a9, // bcrvBBTC
             0x410e3E86ef427e30B9235497143881f717d93c2A, // bbtcCrv
             0xC45b2EEe6e09cA176Ca3bB5f7eEe7C47bF93c756, // bbtcCrv zap
@@ -142,7 +141,7 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
         emit GovernanceUpdated(governance);
     }
 
-    function addZapConfig(
+    function setZapConfig(
         address _sett,
         address _token,
         address _curvePool,
@@ -150,7 +149,7 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
         int128 _withdrawTokenIndex
     ) external {
         _onlyGovernance();
-        _addZapConfig(
+        _setZapConfig(
             _sett,
             _token,
             _curvePool,
@@ -159,32 +158,25 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
         );
     }
 
-    function setZapConfig(
-        uint256 _idx,
+    function setZapConfigWithdrawToken(
         address _sett,
-        address _token,
-        address _curvePool,
         address _withdrawToken,
         int128 _withdrawTokenIndex
     ) external {
         _onlyGovernance();
 
-        require(_sett != address(0));
-        require(_token != address(0));
+        require(address(settZapConfigs[_sett].token) != address(0));
         require(
             _withdrawToken == address(WBTC) || _withdrawToken == address(RENBTC)
         );
 
-        zapConfigs[_idx].sett = ISett(_sett);
-        zapConfigs[_idx].token = IERC20Upgradeable(_token);
-        zapConfigs[_idx].curvePool = ICurveFi(_curvePool);
-        zapConfigs[_idx].withdrawToken = IERC20Upgradeable(_withdrawToken);
-        zapConfigs[_idx].withdrawTokenIndex = _withdrawTokenIndex;
+        settZapConfigs[_sett].withdrawToken = IERC20Upgradeable(_withdrawToken);
+        settZapConfigs[_sett].withdrawTokenIndex = _withdrawTokenIndex;
     }
 
     /// ===== Internal Implementations =====
 
-    function _addZapConfig(
+    function _setZapConfig(
         address _sett,
         address _token,
         address _curvePool,
@@ -197,16 +189,14 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
             _withdrawToken == address(WBTC) || _withdrawToken == address(RENBTC)
         );
 
-        zapConfigs.push(
-            ZapConfig({
-                sett: ISett(_sett),
-                token: IERC20Upgradeable(_token),
-                curvePool: ICurveFi(_curvePool),
-                withdrawToken: IERC20Upgradeable(_withdrawToken),
-                withdrawTokenIndex: _withdrawTokenIndex
-            })
-        );
+        settZapConfigs[_sett] = ZapConfig({
+            token: IERC20Upgradeable(_token),
+            curvePool: ICurveFi(_curvePool),
+            withdrawToken: IERC20Upgradeable(_withdrawToken),
+            withdrawTokenIndex: _withdrawTokenIndex
+        });
         if (_curvePool != address(0)) {
+            IERC20Upgradeable(_token).safeApprove(_curvePool, 0);
             IERC20Upgradeable(_token).safeApprove(
                 _curvePool,
                 type(uint256).max
@@ -216,24 +206,27 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
 
     /// ===== Public Functions =====
 
-    function calcMint(uint256 _shares, uint256 _settIdx)
+    function calcMint(address _sett, uint256 _shares)
         public
         view
         returns (uint256)
     {
+        ZapConfig memory zapConfig = settZapConfigs[_sett];
+
+        // Check if valid sett
+        require(address(zapConfig.token) != address(0));
+
         if (_shares == 0) {
             return 0;
         }
 
-        ZapConfig memory zapConfig = zapConfigs[_settIdx];
-
         // Get price per share
         uint256 pricePerShare;
-        if (address(zapConfig.sett) == WBTC_YEARN_SETT) {
+        if (_sett == WBTC_YEARN_SETT) {
             // byvWBTC doesn't support getPricePerFullShare
-            pricePerShare = IYearnSett(address(zapConfig.sett)).pricePerShare();
+            pricePerShare = IYearnSett(_sett).pricePerShare();
         } else {
-            pricePerShare = zapConfig.sett.getPricePerFullShare();
+            pricePerShare = ISett(_sett).getPricePerFullShare();
         }
 
         // Withdraw (0.1% withdrawal fee)
@@ -241,7 +234,7 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
             .mul(pricePerShare)
             .mul(MAX_FEE.sub(SETT_WITHDRAWAL_FEE))
             .div(MAX_FEE)
-            .div(10**zapConfig.sett.decimals());
+            .div(10**ISett(_sett).decimals());
 
         // Underlying of bvyWBTC is WBTC
         uint256 btcAmount = underlyingAmount;
@@ -263,10 +256,14 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
     }
 
     function mint(
+        address _sett,
         uint256 _shares,
-        uint256 _settIdx,
         uint256 _minOut
     ) public whenNotPaused returns (uint256) {
+        ZapConfig memory zapConfig = settZapConfigs[_sett];
+
+        // Valid sett
+        require(address(zapConfig.token) != address(0));
         // Non-zero shares
         require(_shares > 0, "No shares");
         // Ensure mint zap isn't block locked
@@ -275,24 +272,22 @@ contract SettToRenIbbtcZap is PausableUpgradeable {
             "blockLocked"
         );
 
-        ZapConfig memory zapConfig = zapConfigs[_settIdx];
-
-        if (address(zapConfig.sett) != WBTC_YEARN_SETT) {
+        if (_sett != WBTC_YEARN_SETT) {
             // Not block locked by sett
             require(
-                zapConfig.sett.blockLock(address(this)) < block.number,
+                ISett(_sett).blockLock(address(this)) < block.number,
                 "blockLocked"
             );
         }
 
-        IERC20Upgradeable(address(zapConfig.sett)).safeTransferFrom(
+        IERC20Upgradeable(_sett).safeTransferFrom(
             msg.sender,
             address(this),
             _shares
         );
 
         // Withdraw from sett
-        zapConfig.sett.withdraw(_shares);
+        ISett(_sett).withdraw(_shares);
         uint256 underlyingAmount = zapConfig.token.balanceOf(address(this));
 
         // Underlying of bvyWBTC is WBTC


### PR DESCRIPTION
Fixes #9 
- Use mapping so you don't have to maintain token index off-chain

TODO:
- [ ] Maybe update `calcMint` to find whether it's better to withdraw in ren or wbtc